### PR TITLE
upgrade mongodb native driver to 2.0.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mocha": "*"
   },
   "dependencies": {
-    "mongodb": "^1.4.30",
+    "mongodb": "^2.0.43",
     "mongodb-uri": "^0.9.7",
     "pre-commit": "^1.0.2",
     "thunky": "^0.1.0"


### PR DESCRIPTION
Develop Environment:
1. mongodb 3.0.2
2. nodejs 4.1.0

Issues:
with low version of mongodb native driver, “Failed to load c++ bson
extension, using pure JS version” will occurred under nodejs v4.1