### PR TITLE
Remove “pre-commit” as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "mongodb": "^2.0.47",
     "mongodb-uri": "^0.9.7",
-    "pre-commit": "^1.1.2",
     "thunky": "^0.1.0"
   }
 }


### PR DESCRIPTION
Installing `pre-commit` also affects the git pre-commit hook of the parent module