### PR TITLE
Use Mongo's native TTL functionality to expire entries and avoid db leak

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,19 +49,27 @@ export default class MongoStore {
     }
 
     conn = conn || 'mongodb://127.0.0.1:27017';
-    this.coll = options.collection || 'cacheman';
+    var coll = this.coll = options.collection || 'cacheman';
     this.compression = options.compression || false;
     this.ready = thunky((cb) => {
+
+      function createIndex(err, db) {
+        db.ensureIndex(coll, { 'expireAt': 1 }, { expireAfterSeconds: 0 }, function(err) {
+          cb(err, db);
+        });
+      }
+
       if ('string' === typeof conn) {
         MongoClient.connect(conn, options, (err, db) => {
           if (err) return cb(err);
-          cb(null, this.client = db);
+          createIndex(null, this.client = db);
         });
       } else {
-        if (this.client) return cb(null, this.client);
+        if (this.client) return createIndex(null, this.client);
         cb(new Error('Invalid mongo connection.'));
       }
     });
+
   }
 
   /**
@@ -78,7 +86,8 @@ export default class MongoStore {
       db.collection(this.coll).findOne({ key: key }, (err, data) => {
         if (err) return fn(err);
         if (!data) return fn(null, null);
-        if (data.expire < Date.now()) {
+        //Mongo's TTL might have a delay, to fully respect the TTL, it is best to validate it in get.
+        if (data.expireAt.getTime() < Date.now()) { 
           this.del(key);
           return fn(null, null);
         }
@@ -118,7 +127,7 @@ export default class MongoStore {
       data = {
         key: key,
         value: val,
-        expire: Date.now() + ((ttl || 60) * 1000)
+        expireAt: new Date(Date.now() + ((ttl || 60) * 1000))
       };
     } catch (err) {
       return fn(err);


### PR DESCRIPTION
This change leverages Mongo's expire functionality: https://docs.mongodb.org/v3.0/tutorial/expire-data/ and avoid potential DB leak if cache entries are not queried after they expired.